### PR TITLE
Expose glyph fragment interfaces

### DIFF
--- a/src/glitch/gojibake-glyph-element.ts
+++ b/src/glitch/gojibake-glyph-element.ts
@@ -6,6 +6,8 @@ import {
   QUAD_FRAGMENT_REGIONS,
 } from "./gojibake-glyph-fragment-element.js";
 
+export type GojibakeGlyphLayout = "dual" | "quad" | null;
+
 /** span 生成直前の正規化済みフラグメント */
 type RenderFragment = {
   glyph: string;
@@ -181,6 +183,27 @@ export class GojibakeGlyphElement extends HTMLElement {
     this.render();
   }
 
+  public get fragments(): GojibakeGlyphFragmentElement[] {
+    return Array.from(this.children).filter(
+      (node): node is GojibakeGlyphFragmentElement =>
+        node.tagName === FRAGMENT_TAG_NAME && node instanceof GojibakeGlyphFragmentElement,
+    );
+  }
+
+  public get layout(): GojibakeGlyphLayout {
+    const fragmentCount = this.fragments.length;
+
+    if (fragmentCount === 2) {
+      return "dual";
+    }
+
+    if (fragmentCount === 4) {
+      return "quad";
+    }
+
+    return null;
+  }
+
   private render(): void {
     const baseChar = this.textContent ?? "";
     const fragments = this.readRenderFragments();
@@ -222,7 +245,7 @@ export class GojibakeGlyphElement extends HTMLElement {
       return [];
     }
 
-    if (elements.length === 2) {
+    if (this.layout === "dual") {
       const fragments = this.readDualRenderFragments(elements);
 
       if (fragments.length !== 2) {
@@ -241,7 +264,7 @@ export class GojibakeGlyphElement extends HTMLElement {
       return fragments.map(({ position: _, ...fragment }) => fragment);
     }
 
-    if (elements.length === 4) {
+    if (this.layout === "quad") {
       const fragments = this.readQuadRenderFragments(elements);
 
       if (fragments.length !== 4) {
@@ -267,9 +290,7 @@ export class GojibakeGlyphElement extends HTMLElement {
   }
 
   private readFragmentElements(): GojibakeGlyphFragmentElement[] | null {
-    const children = Array.from(this.children);
-
-    for (const node of children) {
+    for (const node of Array.from(this.children)) {
       if (node.tagName !== FRAGMENT_TAG_NAME) {
         this.reportConfigurationWarning(
           `子要素には <gojibake-glyph-fragment> を使用してください。<${node.localName}> はサポートしていません。`,
@@ -278,10 +299,7 @@ export class GojibakeGlyphElement extends HTMLElement {
       }
     }
 
-    return children.filter(
-      (node): node is GojibakeGlyphFragmentElement =>
-        node.tagName === FRAGMENT_TAG_NAME && node instanceof GojibakeGlyphFragmentElement,
-    );
+    return this.fragments;
   }
 
   private readDualRenderFragments(elements: GojibakeGlyphFragmentElement[]): DualRenderFragment[] {
@@ -334,7 +352,11 @@ export class GojibakeGlyphElement extends HTMLElement {
         }
 
         const region = element.region;
-        if (region === null || !isOneOf(region, validRegions)) {
+        if (region === null) {
+          return null;
+        }
+
+        if (!isOneOf(region, validRegions)) {
           return null;
         }
 

--- a/src/glitch/gojibake-glyph-fragment-element.ts
+++ b/src/glitch/gojibake-glyph-fragment-element.ts
@@ -1,4 +1,5 @@
 import type { DualCompositePosition, QuadCompositeQuadrant } from "./composite-effect-builder.js";
+import type { GojibakeGlyphLayout } from "./gojibake-glyph-element.js";
 
 type AttributeValidationRule = {
   attributeName: string;
@@ -54,37 +55,38 @@ export class GojibakeGlyphFragmentElement extends HTMLElement {
   }
 
   public get region(): FragmentRegion | null {
-    const layout = this.resolveCompositeLayout();
+    const layout = this.resolveParentLayout();
 
-    switch (layout) {
-      case "dual":
-        return this.readValidatedAttribute({
-          attributeName: "region",
-          allowEmpty: false,
-          choices: DUAL_FRAGMENT_REGIONS,
-          createInvalidMessage(value: string): string {
-            return `dual 構成の region 属性は "top"・"bottom"・"left"・"right" のいずれかを指定してください。現在の値: "${value}"。`;
-          },
-        });
-      case "quad":
-        return this.readValidatedAttribute({
-          attributeName: "region",
-          allowEmpty: false,
-          choices: QUAD_FRAGMENT_REGIONS,
-          createInvalidMessage(value: string): string {
-            return `quad 構成の region 属性は "top-left"・"top-right"・"bottom-left"・"bottom-right" のいずれかを指定してください。現在の値: "${value}"。`;
-          },
-        });
-      default:
-        return this.readValidatedAttribute({
-          attributeName: "region",
-          allowEmpty: false,
-          choices: ALL_FRAGMENT_REGIONS,
-          createInvalidMessage(value: string): string {
-            return `region 属性は "top"・"bottom"・"left"・"right"・"top-left"・"top-right"・"bottom-left"・"bottom-right" のいずれかを指定してください。現在の値: "${value}"。`;
-          },
-        });
+    if (layout === "dual") {
+      return this.readValidatedAttribute({
+        attributeName: "region",
+        allowEmpty: false,
+        choices: DUAL_FRAGMENT_REGIONS,
+        createInvalidMessage(value: string): string {
+          return `dual 構成の region 属性は "top"・"bottom"・"left"・"right" のいずれかを指定してください。現在の値: "${value}"。`;
+        },
+      });
     }
+
+    if (layout === "quad") {
+      return this.readValidatedAttribute({
+        attributeName: "region",
+        allowEmpty: false,
+        choices: QUAD_FRAGMENT_REGIONS,
+        createInvalidMessage(value: string): string {
+          return `quad 構成の region 属性は "top-left"・"top-right"・"bottom-left"・"bottom-right" のいずれかを指定してください。現在の値: "${value}"。`;
+        },
+      });
+    }
+
+    return this.readValidatedAttribute({
+      attributeName: "region",
+      allowEmpty: false,
+      choices: ALL_FRAGMENT_REGIONS,
+      createInvalidMessage(value: string): string {
+        return `region 属性は "top"・"bottom"・"left"・"right"・"top-left"・"top-right"・"bottom-left"・"bottom-right" のいずれかを指定してください。現在の値: "${value}"。`;
+      },
+    });
   }
 
   public get placement(): PlacementMode | null {
@@ -98,23 +100,19 @@ export class GojibakeGlyphFragmentElement extends HTMLElement {
     });
   }
 
-  private resolveCompositeLayout(): "dual" | "quad" | null {
+  private resolveParentLayout(): GojibakeGlyphLayout {
     const parent = this.parentElement;
 
-    if (parent?.tagName !== "GOJIBAKE-GLYPH") {
+    if (
+      parent?.tagName !== "GOJIBAKE-GLYPH" ||
+      !("layout" in parent) ||
+      typeof parent.layout !== "string"
+    ) {
       return null;
     }
 
-    const fragmentCount = Array.from(parent.children).filter(
-      (node) => node.tagName === this.tagName,
-    ).length;
-
-    if (fragmentCount === 2) {
-      return "dual";
-    }
-
-    if (fragmentCount === 4) {
-      return "quad";
+    if (parent.layout === "dual" || parent.layout === "quad") {
+      return parent.layout;
     }
 
     return null;


### PR DESCRIPTION
## 概要
- `<gojibake-glyph>` に公開 getter として `fragments` / `layout` を追加
- `<gojibake-glyph-fragment>` は親の公開 `layout` インターフェースを見て `region` を検証
- 親子ともに DOM 的な公開責務を明確化しつつ、内部での子要素探索処理を `fragments` に集約

## 確認
- `bun run check:fix`
- `bun run check`
- `bun run typecheck`
- `bun run dev` でブラウザ表示確認