### PR TITLE
Add fragment parentGlyph getter

### DIFF
--- a/src/glitch/gojibake-glyph-fragment-element.ts
+++ b/src/glitch/gojibake-glyph-fragment-element.ts
@@ -1,5 +1,5 @@
 import type { DualCompositePosition, QuadCompositeQuadrant } from "./composite-effect-builder.js";
-import type { GojibakeGlyphLayout } from "./gojibake-glyph-element.js";
+import type { GojibakeGlyphElement, GojibakeGlyphLayout } from "./gojibake-glyph-element.js";
 
 type AttributeValidationRule = {
   attributeName: string;
@@ -54,6 +54,16 @@ export class GojibakeGlyphFragmentElement extends HTMLElement {
     });
   }
 
+  public get parentGlyph(): GojibakeGlyphElement | null {
+    const parent = this.parentElement;
+
+    if (parent?.tagName !== "GOJIBAKE-GLYPH") {
+      return null;
+    }
+
+    return parent as GojibakeGlyphElement;
+  }
+
   public get region(): FragmentRegion | null {
     const layout = this.resolveParentLayout();
 
@@ -101,21 +111,13 @@ export class GojibakeGlyphFragmentElement extends HTMLElement {
   }
 
   private resolveParentLayout(): GojibakeGlyphLayout {
-    const parent = this.parentElement;
+    const parent = this.parentGlyph;
 
-    if (
-      parent?.tagName !== "GOJIBAKE-GLYPH" ||
-      !("layout" in parent) ||
-      typeof parent.layout !== "string"
-    ) {
+    if (parent === null) {
       return null;
     }
 
-    if (parent.layout === "dual" || parent.layout === "quad") {
-      return parent.layout;
-    }
-
-    return null;
+    return parent.layout;
   }
 
   private readValidatedAttribute<T extends string>(


### PR DESCRIPTION
## 概要
- `<gojibake-glyph-fragment>` に `parentGlyph` getter を追加
- 親レイアウトの解決を `parentElement` 直接参照ではなく `parentGlyph` 経由に整理
- 子要素から親要素への意味付き参照を公開インターフェース化

## 確認
- `bun run check:fix`
- `bun run check`
- `bun run typecheck`
- `bun run dev` でブラウザ表示確認