### PR TITLE
Use text content for gojibake glyph fragments

### DIFF
--- a/src/glitch/gojibake-glyph-element.test.ts
+++ b/src/glitch/gojibake-glyph-element.test.ts
@@ -57,13 +57,13 @@ describe("GojibakeGlyphElement", () => {
       {
         title: "fragment が 2 個なら dual を返す",
         fragments:
-          '<gojibake-glyph-fragment glyph="上" region="top" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="下" region="bottom" placement="same-side"></gojibake-glyph-fragment>',
+          '<gojibake-glyph-fragment region="top" placement="same-side">上</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom" placement="same-side">下</gojibake-glyph-fragment>',
         expected: "dual",
       },
       {
         title: "fragment が 4 個なら quad を返す",
         fragments:
-          '<gojibake-glyph-fragment glyph="上" region="top" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="下" region="bottom" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="左下" region="bottom-left" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="右下" region="bottom-right" placement="same-side"></gojibake-glyph-fragment>',
+          '<gojibake-glyph-fragment region="top" placement="same-side">上</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom" placement="same-side">下</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-left" placement="same-side">左下</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-right" placement="same-side">右下</gojibake-glyph-fragment>',
         expected: "quad",
       },
     ] as const)("$title", ({ fragments, expected }) => {
@@ -77,7 +77,7 @@ describe("GojibakeGlyphElement", () => {
     it("gojibake-glyph-fragment の子要素だけを返す", () => {
       const glyph = renderGlyphFixture(
         "基",
-        '<gojibake-glyph-fragment glyph="上" region="top" placement="same-side"></gojibake-glyph-fragment><span></span><gojibake-glyph-fragment glyph="下" region="bottom" placement="same-side"></gojibake-glyph-fragment>',
+        '<gojibake-glyph-fragment region="top" placement="same-side">上</gojibake-glyph-fragment><span></span><gojibake-glyph-fragment region="bottom" placement="same-side">下</gojibake-glyph-fragment>',
       );
 
       expect(glyph.fragments).toHaveLength(2);
@@ -107,7 +107,7 @@ describe("GojibakeGlyphElement", () => {
       it("span 群へ正規化して描画する", () => {
         const glyph = renderGlyphFixture(
           "基",
-          '<gojibake-glyph-fragment glyph="上" region="top" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="下" region="bottom" placement="opposite-side"></gojibake-glyph-fragment>',
+          '<gojibake-glyph-fragment region="top" placement="same-side">上</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom" placement="opposite-side">下</gojibake-glyph-fragment>',
         );
 
         glyph.connectedCallback();
@@ -131,7 +131,7 @@ describe("GojibakeGlyphElement", () => {
       it("不正な region 組み合わせは警告してフォールバックする", () => {
         const glyph = renderGlyphFixture(
           "基",
-          '<gojibake-glyph-fragment glyph="上" region="top" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="右" region="right" placement="same-side"></gojibake-glyph-fragment>',
+          '<gojibake-glyph-fragment region="top" placement="same-side">上</gojibake-glyph-fragment><gojibake-glyph-fragment region="right" placement="same-side">右</gojibake-glyph-fragment>',
         );
 
         glyph.connectedCallback();
@@ -148,7 +148,7 @@ describe("GojibakeGlyphElement", () => {
       it("4 象限をそれぞれ描画する", () => {
         const glyph = renderGlyphFixture(
           "基",
-          '<gojibake-glyph-fragment glyph="左上" region="top-left" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="右上" region="top-right" placement="opposite-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="左下" region="bottom-left" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="右下" region="bottom-right" placement="opposite-side"></gojibake-glyph-fragment>',
+          '<gojibake-glyph-fragment region="top-left" placement="same-side">左上</gojibake-glyph-fragment><gojibake-glyph-fragment region="top-right" placement="opposite-side">右上</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-left" placement="same-side">左下</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-right" placement="opposite-side">右下</gojibake-glyph-fragment>',
         );
 
         glyph.connectedCallback();
@@ -169,7 +169,7 @@ describe("GojibakeGlyphElement", () => {
       it("quadrant が重複していると警告してフォールバックする", () => {
         const glyph = renderGlyphFixture(
           "基",
-          '<gojibake-glyph-fragment glyph="左上1" region="top-left" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="右上" region="top-right" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="左下" region="bottom-left" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="左上2" region="top-left" placement="same-side"></gojibake-glyph-fragment>',
+          '<gojibake-glyph-fragment region="top-left" placement="same-side">左上1</gojibake-glyph-fragment><gojibake-glyph-fragment region="top-right" placement="same-side">右上</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-left" placement="same-side">左下</gojibake-glyph-fragment><gojibake-glyph-fragment region="top-left" placement="same-side">左上2</gojibake-glyph-fragment>',
         );
 
         glyph.connectedCallback();

--- a/src/glitch/gojibake-glyph-element.ts
+++ b/src/glitch/gojibake-glyph-element.ts
@@ -157,17 +157,17 @@ function isOneOf<T extends string>(value: string, choices: readonly T[]): value 
  * composite（dual / quad）グリッチ効果を表示するカスタム要素。
  *
  * - `textContent` に元文字を指定する
- * - 各断片は `<gojibake-glyph-fragment>` 子要素で指定する
+ * - 各断片は `<gojibake-glyph-fragment>` 子要素の `textContent` で指定する
  * - 子要素数が 2 のとき dual、4 のとき quad とみなす
- *   - dual の場合: 各子要素は `glyph`, `region`, `placement` を持つ
- *   - quad の場合: 各子要素は `glyph`, `region`, `placement` を持つ
+ *   - dual の場合: 各子要素は本文と `region`, `placement` を持つ
+ *   - quad の場合: 各子要素は本文と `region`, `placement` を持つ
  *
  * @example
  * // dual composite（上下分割）
  * // <gojibake-glyph>
  * //   あ
- * //   <gojibake-glyph-fragment glyph="い" region="top" placement="same-side"></gojibake-glyph-fragment>
- * //   <gojibake-glyph-fragment glyph="う" region="bottom" placement="opposite-side"></gojibake-glyph-fragment>
+ * //   <gojibake-glyph-fragment region="top" placement="same-side">い</gojibake-glyph-fragment>
+ * //   <gojibake-glyph-fragment region="bottom" placement="opposite-side">う</gojibake-glyph-fragment>
  * // </gojibake-glyph>
  */
 export class GojibakeGlyphElement extends HTMLElement {
@@ -205,7 +205,7 @@ export class GojibakeGlyphElement extends HTMLElement {
   }
 
   private render(): void {
-    const baseChar = this.textContent ?? "";
+    const baseChar = this.readBaseChar();
     const fragments = this.readRenderFragments();
 
     const base = document.createElement("span");
@@ -231,6 +231,13 @@ export class GojibakeGlyphElement extends HTMLElement {
     }
 
     this.shadow.replaceChildren(df);
+  }
+
+  private readBaseChar(): string {
+    return Array.from(this.childNodes)
+      .filter((node): node is Text => node.nodeType === Node.TEXT_NODE)
+      .map((node) => node.data)
+      .join("");
   }
 
   /**

--- a/src/glitch/gojibake-glyph-fragment-element.test.ts
+++ b/src/glitch/gojibake-glyph-fragment-element.test.ts
@@ -43,21 +43,21 @@ describe("GojibakeGlyphFragmentElement", () => {
   });
 
   describe("glyph", () => {
-    it("glyph 属性があればそのまま返す", () => {
-      renderFixture('<gojibake-glyph-fragment glyph="異"></gojibake-glyph-fragment>');
+    it("textContent があればそのまま返す", () => {
+      renderFixture("<gojibake-glyph-fragment>異</gojibake-glyph-fragment>");
       const element = getFragment();
 
       expect(element.glyph).toBe("異");
       expect(warnings).toEqual([]);
     });
 
-    it("glyph 属性が欠けていると警告して null を返す", () => {
+    it("textContent が空なら警告して null を返す", () => {
       renderFixture("<gojibake-glyph-fragment></gojibake-glyph-fragment>");
       const element = getFragment();
 
       expect(element.glyph).toBeNull();
       expect(warnings).toEqual([
-        "<gojibake-glyph-fragment>: glyph 属性が不正です。glyph 属性は必須です。",
+        "<gojibake-glyph-fragment>: glyphが不正です。glyph テキストは必須です。",
       ]);
     });
   });
@@ -65,7 +65,7 @@ describe("GojibakeGlyphFragmentElement", () => {
   describe("parentGlyph", () => {
     it("gojibake-glyph 親があれば parentGlyph として返す", () => {
       renderFixture(
-        '<gojibake-glyph><gojibake-glyph-fragment glyph="片"></gojibake-glyph-fragment></gojibake-glyph>',
+        "<gojibake-glyph><gojibake-glyph-fragment>片</gojibake-glyph-fragment></gojibake-glyph>",
       );
       const parent = getGlyph();
       const child = getFragment();
@@ -74,7 +74,7 @@ describe("GojibakeGlyphFragmentElement", () => {
     });
 
     it("gojibake-glyph 親でなければ null を返す", () => {
-      renderFixture('<span><gojibake-glyph-fragment glyph="片"></gojibake-glyph-fragment></span>');
+      renderFixture("<span><gojibake-glyph-fragment>片</gojibake-glyph-fragment></span>");
       const child = getFragment();
 
       expect(child.parentGlyph).toBeNull();
@@ -106,7 +106,7 @@ describe("GojibakeGlyphFragmentElement", () => {
         },
       ] as const)("$title", ({ region, expected, warnings: expectedWarnings }) => {
         renderFixture(
-          `<gojibake-glyph><gojibake-glyph-fragment glyph="化" region="${region}"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="字" region="bottom" placement="same-side"></gojibake-glyph-fragment></gojibake-glyph>`,
+          `<gojibake-glyph><gojibake-glyph-fragment region="${region}">化</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom" placement="same-side">字</gojibake-glyph-fragment></gojibake-glyph>`,
         );
         const parent = getGlyph();
         const [target] = parent.fragments;
@@ -135,7 +135,7 @@ describe("GojibakeGlyphFragmentElement", () => {
         },
       ] as const)("$title", ({ region, expected, warnings: expectedWarnings }) => {
         renderFixture(
-          `<gojibake-glyph><gojibake-glyph-fragment glyph="化" region="${region}" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="字" region="top-right" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="崩" region="bottom-left" placement="same-side"></gojibake-glyph-fragment><gojibake-glyph-fragment glyph="壊" region="bottom-right" placement="same-side"></gojibake-glyph-fragment></gojibake-glyph>`,
+          `<gojibake-glyph><gojibake-glyph-fragment region="${region}" placement="same-side">化</gojibake-glyph-fragment><gojibake-glyph-fragment region="top-right" placement="same-side">字</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-left" placement="same-side">崩</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-right" placement="same-side">壊</gojibake-glyph-fragment></gojibake-glyph>`,
         );
         const parent = getGlyph();
         const [target] = parent.fragments;
@@ -147,9 +147,7 @@ describe("GojibakeGlyphFragmentElement", () => {
     });
 
     it("親レイアウトが未確定なら全 region から検証する", () => {
-      renderFixture(
-        '<gojibake-glyph-fragment glyph="片" region="bottom-right"></gojibake-glyph-fragment>',
-      );
+      renderFixture('<gojibake-glyph-fragment region="bottom-right">片</gojibake-glyph-fragment>');
       const element = getFragment();
 
       expect(element.region).toBe("bottom-right");
@@ -157,9 +155,7 @@ describe("GojibakeGlyphFragmentElement", () => {
     });
 
     it("親レイアウトが未確定でも不正な region は警告して null を返す", () => {
-      renderFixture(
-        '<gojibake-glyph-fragment glyph="片" region="center"></gojibake-glyph-fragment>',
-      );
+      renderFixture('<gojibake-glyph-fragment region="center">片</gojibake-glyph-fragment>');
       const element = getFragment();
       const region = element.region;
 
@@ -171,7 +167,7 @@ describe("GojibakeGlyphFragmentElement", () => {
     });
 
     it("region 属性がなければ警告して null を返す", () => {
-      renderFixture('<gojibake-glyph-fragment glyph="片"></gojibake-glyph-fragment>');
+      renderFixture("<gojibake-glyph-fragment>片</gojibake-glyph-fragment>");
       const element = getFragment();
 
       expect(element.region).toBeNull();
@@ -214,7 +210,7 @@ describe("GojibakeGlyphFragmentElement", () => {
     });
 
     it("placement 属性がなければ警告して null を返す", () => {
-      renderFixture('<gojibake-glyph-fragment glyph="片" region="top"></gojibake-glyph-fragment>');
+      renderFixture('<gojibake-glyph-fragment region="top">片</gojibake-glyph-fragment>');
       const element = getFragment();
 
       expect(element.placement).toBeNull();

--- a/src/glitch/gojibake-glyph-fragment-element.ts
+++ b/src/glitch/gojibake-glyph-fragment-element.ts
@@ -17,6 +17,11 @@ type FreeformAttributeValidationRule = AttributeValidationRule & {
   createInvalidMessage?: undefined;
 };
 
+type TextContentValidationRule = {
+  required?: boolean;
+  allowEmpty?: boolean;
+};
+
 export const DUAL_FRAGMENT_REGIONS = [
   "top",
   "bottom",
@@ -49,8 +54,8 @@ function hasChoices<T extends string>(
 
 export class GojibakeGlyphFragmentElement extends HTMLElement {
   public get glyph(): string | null {
-    return this.readValidatedAttribute({
-      attributeName: "glyph",
+    return this.readValidatedTextContent({
+      allowEmpty: false,
     });
   }
 
@@ -149,7 +154,27 @@ export class GojibakeGlyphFragmentElement extends HTMLElement {
     return value;
   }
 
+  private readValidatedTextContent(rule: TextContentValidationRule): string | null {
+    const { required = true, allowEmpty = true } = rule;
+    const value = this.textContent;
+
+    if (value === null || (!allowEmpty && value === "")) {
+      if (!required) {
+        return null;
+      }
+
+      this.reportValueWarning("glyph", "glyph テキストは必須です。");
+      return null;
+    }
+
+    return value;
+  }
+
   private reportAttributeWarning(attributeName: string, message: string): void {
-    console.warn(`<gojibake-glyph-fragment>: ${attributeName} 属性が不正です。${message}`);
+    this.reportValueWarning(`${attributeName} 属性`, message);
+  }
+
+  private reportValueWarning(target: string, message: string): void {
+    console.warn(`<gojibake-glyph-fragment>: ${target}が不正です。${message}`);
   }
 }

--- a/src/glitch/renderer.ts
+++ b/src/glitch/renderer.ts
@@ -26,8 +26,8 @@ export class GlitchRenderer {
    * // source = "AB" で A が dual composite、B が通常文字の場合:
    * // <gojibake-glyph>
    * //   A
-   * //   <gojibake-glyph-fragment glyph="い" region="top" placement="same-side"></gojibake-glyph-fragment>
-   * //   <gojibake-glyph-fragment glyph="う" region="bottom" placement="opposite-side"></gojibake-glyph-fragment>
+   * //   <gojibake-glyph-fragment region="top" placement="same-side">い</gojibake-glyph-fragment>
+   * //   <gojibake-glyph-fragment region="bottom" placement="opposite-side">う</gojibake-glyph-fragment>
    * // </gojibake-glyph>
    * // <span class="char">
    * //   <span class="char__base">B</span>
@@ -99,7 +99,7 @@ export class GlitchRenderer {
     if (composite.kind === "dual") {
       composite.fragments.forEach((fragment) => {
         const fragmentEl = document.createElement("gojibake-glyph-fragment");
-        fragmentEl.setAttribute("glyph", fragment.char);
+        fragmentEl.textContent = fragment.char;
         fragmentEl.setAttribute("region", fragment.position);
         fragmentEl.setAttribute("placement", fragment.placement);
         el.appendChild(fragmentEl);
@@ -107,7 +107,7 @@ export class GlitchRenderer {
     } else {
       composite.fragments.forEach((fragment) => {
         const fragmentEl = document.createElement("gojibake-glyph-fragment");
-        fragmentEl.setAttribute("glyph", fragment.char);
+        fragmentEl.textContent = fragment.char;
         fragmentEl.setAttribute("region", fragment.quadrant);
         fragmentEl.setAttribute("placement", fragment.placement);
         el.appendChild(fragmentEl);


### PR DESCRIPTION
## 概要
- `gojibake-glyph-fragment` がグリフを属性ではなく `textContent` から読むよう変更
- レンダラーとテストを新しい記法に合わせて更新
- `gojibake-glyph` は子断片の本文に影響されず元文字を読めるよう調整

## 確認
- `bun test`
- `bun run check:fix`
- `bun run typecheck`
- `bun run build`
- `bun run dev` でブラウザ確認