### PR TITLE
fix: separate fragment region semantics from glyph layout

### DIFF
--- a/src/glitch/gojibake-glyph-element.test.ts
+++ b/src/glitch/gojibake-glyph-element.test.ts
@@ -142,6 +142,21 @@ describe("GojibakeGlyphElement", () => {
           '<gojibake-glyph>: dual 構成の region 属性は "top" と "bottom"、または "left" と "right" を 1 つずつ指定してください。',
         ]);
       });
+
+      it("quad 用 region が混ざると警告してフォールバックする", () => {
+        const glyph = renderGlyphFixture(
+          "基",
+          '<gojibake-glyph-fragment region="top-left" placement="same-side">左上</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom" placement="same-side">下</gojibake-glyph-fragment>',
+        );
+
+        glyph.connectedCallback();
+
+        expect(readFragments(glyph)).toHaveLength(0);
+        expect(readBase(glyph).classList.contains("base--fallback")).toBe(true);
+        expect(warnings).toEqual([
+          '<gojibake-glyph>: dual 構成では region 属性に "top-left" は指定できません。',
+        ]);
+      });
     });
 
     describe("quad 構成", () => {
@@ -178,6 +193,21 @@ describe("GojibakeGlyphElement", () => {
         expect(readBase(glyph).classList.contains("base--fallback")).toBe(true);
         expect(warnings).toEqual([
           '<gojibake-glyph>: quad 構成の region 属性は "top-left"・"top-right"・"bottom-left"・"bottom-right" を 1 つずつ指定してください。',
+        ]);
+      });
+
+      it("dual 用 region が混ざると警告してフォールバックする", () => {
+        const glyph = renderGlyphFixture(
+          "基",
+          '<gojibake-glyph-fragment region="top" placement="same-side">上</gojibake-glyph-fragment><gojibake-glyph-fragment region="top-right" placement="same-side">右上</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-left" placement="same-side">左下</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-right" placement="same-side">右下</gojibake-glyph-fragment>',
+        );
+
+        glyph.connectedCallback();
+
+        expect(readFragments(glyph)).toHaveLength(0);
+        expect(readBase(glyph).classList.contains("base--fallback")).toBe(true);
+        expect(warnings).toEqual([
+          '<gojibake-glyph>: quad 構成では region 属性に "top" は指定できません。',
         ]);
       });
     });

--- a/src/glitch/gojibake-glyph-element.ts
+++ b/src/glitch/gojibake-glyph-element.ts
@@ -364,6 +364,9 @@ export class GojibakeGlyphElement extends HTMLElement {
         }
 
         if (!isOneOf(region, validRegions)) {
+          this.reportConfigurationWarning(
+            `${layout} 構成では region 属性に "${region}" は指定できません。`,
+          );
           return null;
         }
 

--- a/src/glitch/gojibake-glyph-fragment-element.test.ts
+++ b/src/glitch/gojibake-glyph-fragment-element.test.ts
@@ -1,14 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
-import { GojibakeGlyphElement } from "./gojibake-glyph-element.ts";
 import { GojibakeGlyphFragmentElement } from "./gojibake-glyph-fragment-element.ts";
 
 if (!customElements.get("gojibake-glyph-fragment")) {
   customElements.define("gojibake-glyph-fragment", GojibakeGlyphFragmentElement);
-}
-
-if (!customElements.get("gojibake-glyph")) {
-  customElements.define("gojibake-glyph", GojibakeGlyphElement);
 }
 
 let fixtureRoot: HTMLDivElement;
@@ -20,10 +15,6 @@ function renderFixture(markup: string): void {
 
 function getFragment(): GojibakeGlyphFragmentElement {
   return fixtureRoot.querySelector("gojibake-glyph-fragment") as GojibakeGlyphFragmentElement;
-}
-
-function getGlyph(): GojibakeGlyphElement {
-  return fixtureRoot.querySelector("gojibake-glyph") as GojibakeGlyphElement;
 }
 
 describe("GojibakeGlyphFragmentElement", () => {
@@ -43,121 +34,16 @@ describe("GojibakeGlyphFragmentElement", () => {
     });
   });
 
-  describe("parentGlyph", () => {
-    it("gojibake-glyph 親があれば parentGlyph として返す", () => {
-      renderFixture(
-        "<gojibake-glyph><gojibake-glyph-fragment>片</gojibake-glyph-fragment></gojibake-glyph>",
-      );
-      const parent = getGlyph();
-      const child = getFragment();
-
-      expect(child.parentGlyph).toBe(parent);
-    });
-
-    it("gojibake-glyph 親でなければ null を返す", () => {
-      renderFixture("<span><gojibake-glyph-fragment>片</gojibake-glyph-fragment></span>");
-      const child = getFragment();
-
-      expect(child.parentGlyph).toBeNull();
-    });
-  });
-
   describe("region", () => {
     describe("getter", () => {
-      describe("dual 親", () => {
-        it.each([
-          {
-            title: "dual 親では top を受け付ける",
-            region: "top",
-            expected: "top",
-          },
-          {
-            title: "dual 親では bottom を受け付ける",
-            region: "bottom",
-            expected: "bottom",
-          },
-          {
-            title: "dual 親では quad 用 region に invalid value default を適用する",
-            region: "top-left",
-            expected: "top",
-          },
-        ] as const)("$title", ({ region, expected }) => {
-          renderFixture(
-            `<gojibake-glyph><gojibake-glyph-fragment region="${region}">化</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom" placement="same-side">字</gojibake-glyph-fragment></gojibake-glyph>`,
-          );
-          const parent = getGlyph();
-          const [target] = parent.fragments;
+      it("dual 用の region を受け付ける", () => {
+        renderFixture('<gojibake-glyph-fragment region="bottom">片</gojibake-glyph-fragment>');
+        const element = getFragment();
 
-          expect(parent.layout).toBe("dual");
-          expect(target.region).toBe(expected);
-        });
-
-        it("dual 親では region 属性がなければ missing value default を返す", () => {
-          renderFixture(
-            '<gojibake-glyph><gojibake-glyph-fragment placement="same-side">化</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom" placement="same-side">字</gojibake-glyph-fragment></gojibake-glyph>',
-          );
-          const parent = getGlyph();
-          const [target] = parent.fragments;
-
-          expect(target.region).toBe("top");
-        });
-
-        it("dual 親では空文字 region に empty value default を返す", () => {
-          renderFixture(
-            '<gojibake-glyph><gojibake-glyph-fragment region="" placement="same-side">化</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom" placement="same-side">字</gojibake-glyph-fragment></gojibake-glyph>',
-          );
-          const parent = getGlyph();
-          const [target] = parent.fragments;
-
-          expect(target.region).toBe("top");
-        });
+        expect(element.region).toBe("bottom");
       });
 
-      describe("quad 親", () => {
-        it.each([
-          {
-            title: "quad 親では top-left を受け付ける",
-            region: "top-left",
-            expected: "top-left",
-          },
-          {
-            title: "quad 親では dual 用 region に invalid value default を適用する",
-            region: "top",
-            expected: "top-left",
-          },
-        ] as const)("$title", ({ region, expected }) => {
-          renderFixture(
-            `<gojibake-glyph><gojibake-glyph-fragment region="${region}" placement="same-side">化</gojibake-glyph-fragment><gojibake-glyph-fragment region="top-right" placement="same-side">字</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-left" placement="same-side">崩</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-right" placement="same-side">壊</gojibake-glyph-fragment></gojibake-glyph>`,
-          );
-          const parent = getGlyph();
-          const [target] = parent.fragments;
-
-          expect(parent.layout).toBe("quad");
-          expect(target.region).toBe(expected);
-        });
-
-        it("quad 親では region 属性がなければ missing value default を返す", () => {
-          renderFixture(
-            '<gojibake-glyph><gojibake-glyph-fragment placement="same-side">化</gojibake-glyph-fragment><gojibake-glyph-fragment region="top-right" placement="same-side">字</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-left" placement="same-side">崩</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-right" placement="same-side">壊</gojibake-glyph-fragment></gojibake-glyph>',
-          );
-          const parent = getGlyph();
-          const [target] = parent.fragments;
-
-          expect(target.region).toBe("top-left");
-        });
-
-        it("quad 親では空文字 region に empty value default を返す", () => {
-          renderFixture(
-            '<gojibake-glyph><gojibake-glyph-fragment region="" placement="same-side">化</gojibake-glyph-fragment><gojibake-glyph-fragment region="top-right" placement="same-side">字</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-left" placement="same-side">崩</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-right" placement="same-side">壊</gojibake-glyph-fragment></gojibake-glyph>',
-          );
-          const parent = getGlyph();
-          const [target] = parent.fragments;
-
-          expect(target.region).toBe("top-left");
-        });
-      });
-
-      it("親レイアウトが未確定なら全 region から検証する", () => {
+      it("quad 用の region を受け付ける", () => {
         renderFixture(
           '<gojibake-glyph-fragment region="bottom-right">片</gojibake-glyph-fragment>',
         );
@@ -166,7 +52,7 @@ describe("GojibakeGlyphFragmentElement", () => {
         expect(element.region).toBe("bottom-right");
       });
 
-      it("親レイアウトが未確定でも不正な region には invalid value default を返す", () => {
+      it("不正な region には invalid value default を返す", () => {
         renderFixture('<gojibake-glyph-fragment region="center">片</gojibake-glyph-fragment>');
         const element = getFragment();
 

--- a/src/glitch/gojibake-glyph-fragment-element.ts
+++ b/src/glitch/gojibake-glyph-fragment-element.ts
@@ -1,5 +1,4 @@
 import type { DualCompositePosition, QuadCompositeQuadrant } from "./composite-effect-builder.js";
-import { GojibakeGlyphElement, type GojibakeGlyphLayout } from "./gojibake-glyph-element.js";
 
 type EnumeratedAttributeValidationRule<T extends string> = {
   attributeName: string;
@@ -30,8 +29,6 @@ export const QUAD_FRAGMENT_REGIONS = [
 
 const ALL_FRAGMENT_REGIONS = [...DUAL_FRAGMENT_REGIONS, ...QUAD_FRAGMENT_REGIONS] as const;
 const PLACEMENT_MODES = ["same-side", "opposite-side"] as const;
-const DUAL_FRAGMENT_REGION_DEFAULT = DUAL_FRAGMENT_REGIONS[0];
-const QUAD_FRAGMENT_REGION_DEFAULT = QUAD_FRAGMENT_REGIONS[0];
 const FRAGMENT_REGION_DEFAULT = ALL_FRAGMENT_REGIONS[0];
 const PLACEMENT_MODE_DEFAULT = PLACEMENT_MODES[0];
 
@@ -49,39 +46,7 @@ export class GojibakeGlyphFragmentElement extends HTMLElement {
     });
   }
 
-  public get parentGlyph(): GojibakeGlyphElement | null {
-    const parent = this.parentElement;
-
-    if (!(parent instanceof GojibakeGlyphElement)) {
-      return null;
-    }
-
-    return parent;
-  }
-
   public get region(): FragmentRegion | null {
-    const layout = this.resolveParentLayout();
-
-    if (layout === "dual") {
-      return this.readValidatedEnumeratedAttribute({
-        attributeName: "region",
-        choices: DUAL_FRAGMENT_REGIONS,
-        invalidValueDefault: DUAL_FRAGMENT_REGION_DEFAULT,
-        missingValueDefault: DUAL_FRAGMENT_REGION_DEFAULT,
-        emptyValueDefault: DUAL_FRAGMENT_REGION_DEFAULT,
-      });
-    }
-
-    if (layout === "quad") {
-      return this.readValidatedEnumeratedAttribute({
-        attributeName: "region",
-        choices: QUAD_FRAGMENT_REGIONS,
-        invalidValueDefault: QUAD_FRAGMENT_REGION_DEFAULT,
-        missingValueDefault: QUAD_FRAGMENT_REGION_DEFAULT,
-        emptyValueDefault: QUAD_FRAGMENT_REGION_DEFAULT,
-      });
-    }
-
     return this.readValidatedEnumeratedAttribute({
       attributeName: "region",
       choices: ALL_FRAGMENT_REGIONS,
@@ -107,16 +72,6 @@ export class GojibakeGlyphFragmentElement extends HTMLElement {
 
   public set placement(value: PlacementMode) {
     this.setAttribute("placement", value);
-  }
-
-  private resolveParentLayout(): GojibakeGlyphLayout {
-    const parent = this.parentGlyph;
-
-    if (parent === null) {
-      return null;
-    }
-
-    return parent.layout;
   }
 
   private readValidatedEnumeratedAttribute<T extends string>(


### PR DESCRIPTION
## 概要
- `gojibake-glyph-fragment` の `region` を親 layout 非依存の列挙属性として扱うよう整理
- `gojibake-glyph` 側で dual / quad ごとの region 整合性を検証するよう変更
- 責務分離に合わせて関連テストを更新

## 確認
- `bun run check:fix`
- `bun test`
- `bun run typecheck`
- `bun run check`
- `bun run dev` でブラウザ確認