### PR TITLE
gojibake-glyph を 1文字セル描画へ寄せる

### DIFF
--- a/src/glitch/gojibake-glyph-element.test.ts
+++ b/src/glitch/gojibake-glyph-element.test.ts
@@ -19,16 +19,20 @@ function renderFixture(markup: string): GojibakeGlyphElement {
   return fixtureRoot.querySelector("gojibake-glyph") as GojibakeGlyphElement;
 }
 
-function renderGlyphFixture(baseChar: string, fragments = ""): GojibakeGlyphElement {
-  return renderFixture(`<gojibake-glyph>${baseChar}${fragments}</gojibake-glyph>`);
+function renderGlyphFixture(fragments = "", leadingText = ""): GojibakeGlyphElement {
+  return renderFixture(`<gojibake-glyph>${leadingText}${fragments}</gojibake-glyph>`);
 }
 
-function readBase(element: GojibakeGlyphElement): HTMLSpanElement {
-  return element.shadowRoot?.querySelector(".base") as HTMLSpanElement;
+function readBase(element: GojibakeGlyphElement): HTMLSpanElement | null {
+  return element.shadowRoot?.querySelector(".base") ?? null;
 }
 
 function readFragments(element: GojibakeGlyphElement): HTMLSpanElement[] {
   return Array.from(element.shadowRoot?.querySelectorAll(".fragment") ?? []);
+}
+
+function readSlot(element: GojibakeGlyphElement): HTMLSlotElement | null {
+  return element.shadowRoot?.querySelector("slot") ?? null;
 }
 
 describe("GojibakeGlyphElement", () => {
@@ -56,7 +60,7 @@ describe("GojibakeGlyphElement", () => {
         expected: "quad",
       },
     ] as const)("$title", ({ fragments, expected }) => {
-      const glyph = renderGlyphFixture("原", fragments);
+      const glyph = renderGlyphFixture(fragments, "原");
 
       expect(glyph.layout).toBe(expected);
     });
@@ -65,8 +69,8 @@ describe("GojibakeGlyphElement", () => {
   describe("fragments", () => {
     it("gojibake-glyph-fragment の子要素だけを返す", () => {
       const glyph = renderGlyphFixture(
-        "基",
         '<gojibake-glyph-fragment region="top" placement="same-side">上</gojibake-glyph-fragment><span></span><gojibake-glyph-fragment region="bottom" placement="same-side">下</gojibake-glyph-fragment>',
+        "基",
       );
 
       expect(glyph.fragments).toHaveLength(2);
@@ -78,30 +82,29 @@ describe("GojibakeGlyphElement", () => {
   });
 
   describe("connectedCallback", () => {
-    it("fragment がなければフォールバック文字だけを描画する", () => {
-      const glyph = renderGlyphFixture(" ");
+    it("fragment がなければ light DOM をそのまま表示する", () => {
+      const glyph = renderGlyphFixture("", " ");
 
       glyph.connectedCallback();
 
-      const base = readBase(glyph);
-
       expect(readFragments(glyph)).toHaveLength(0);
-      expect(base.classList.contains("base--fallback")).toBe(true);
-      expect(base.textContent).toBe("\u00a0");
+      expect(readBase(glyph)).toBeNull();
+      expect(readSlot(glyph)).not.toBeNull();
     });
 
     describe("dual 構成", () => {
       it("span 群へ正規化して描画する", () => {
         const glyph = renderGlyphFixture(
-          "基",
           '<gojibake-glyph-fragment region="top" placement="same-side">上</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom" placement="opposite-side">下</gojibake-glyph-fragment>',
+          "基",
         );
 
         glyph.connectedCallback();
 
         const [first, second] = readFragments(glyph);
 
-        expect(readBase(glyph).textContent).toBe("基");
+        expect(readBase(glyph)).toBeNull();
+        expect(readSlot(glyph)).toBeNull();
 
         expect(first.dataset.layout).toBe("dual");
         expect(first.dataset.clip).toBe("top");
@@ -114,42 +117,46 @@ describe("GojibakeGlyphElement", () => {
         expect(second.textContent).toBe("下");
       });
 
-      it("不正な region 組み合わせはフォールバックする", () => {
+      it("不正な region 組み合わせなら light DOM をそのまま表示する", () => {
         const glyph = renderGlyphFixture(
-          "基",
           '<gojibake-glyph-fragment region="top" placement="same-side">上</gojibake-glyph-fragment><gojibake-glyph-fragment region="right" placement="same-side">右</gojibake-glyph-fragment>',
+          "基",
         );
 
         glyph.connectedCallback();
 
         expect(readFragments(glyph)).toHaveLength(0);
-        expect(readBase(glyph).classList.contains("base--fallback")).toBe(true);
+        expect(readBase(glyph)).toBeNull();
+        expect(readSlot(glyph)).not.toBeNull();
       });
 
-      it("quad 用 region が混ざるとフォールバックする", () => {
+      it("quad 用 region が混ざると light DOM をそのまま表示する", () => {
         const glyph = renderGlyphFixture(
-          "基",
           '<gojibake-glyph-fragment region="top-left" placement="same-side">左上</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom" placement="same-side">下</gojibake-glyph-fragment>',
+          "基",
         );
 
         glyph.connectedCallback();
 
         expect(readFragments(glyph)).toHaveLength(0);
-        expect(readBase(glyph).classList.contains("base--fallback")).toBe(true);
+        expect(readBase(glyph)).toBeNull();
+        expect(readSlot(glyph)).not.toBeNull();
       });
     });
 
     describe("quad 構成", () => {
       it("4 象限をそれぞれ描画する", () => {
         const glyph = renderGlyphFixture(
-          "基",
           '<gojibake-glyph-fragment region="top-left" placement="same-side">左上</gojibake-glyph-fragment><gojibake-glyph-fragment region="top-right" placement="opposite-side">右上</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-left" placement="same-side">左下</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-right" placement="opposite-side">右下</gojibake-glyph-fragment>',
+          "基",
         );
 
         glyph.connectedCallback();
 
         const [topLeft, topRight, bottomLeft, bottomRight] = readFragments(glyph);
 
+        expect(readBase(glyph)).toBeNull();
+        expect(readSlot(glyph)).toBeNull();
         expect(readFragments(glyph)).toHaveLength(4);
         expect(topLeft.dataset.clip).toBe("top-left");
         expect(topLeft.dataset.place).toBeUndefined();
@@ -160,38 +167,41 @@ describe("GojibakeGlyphElement", () => {
         expect(bottomRight.dataset.place).toBe("bottom-right");
       });
 
-      it("quadrant が重複しているとフォールバックする", () => {
+      it("quadrant が重複していると light DOM をそのまま表示する", () => {
         const glyph = renderGlyphFixture(
-          "基",
           '<gojibake-glyph-fragment region="top-left" placement="same-side">左上1</gojibake-glyph-fragment><gojibake-glyph-fragment region="top-right" placement="same-side">右上</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-left" placement="same-side">左下</gojibake-glyph-fragment><gojibake-glyph-fragment region="top-left" placement="same-side">左上2</gojibake-glyph-fragment>',
+          "基",
         );
 
         glyph.connectedCallback();
 
         expect(readFragments(glyph)).toHaveLength(0);
-        expect(readBase(glyph).classList.contains("base--fallback")).toBe(true);
+        expect(readBase(glyph)).toBeNull();
+        expect(readSlot(glyph)).not.toBeNull();
       });
 
-      it("dual 用 region が混ざるとフォールバックする", () => {
+      it("dual 用 region が混ざると light DOM をそのまま表示する", () => {
         const glyph = renderGlyphFixture(
-          "基",
           '<gojibake-glyph-fragment region="top" placement="same-side">上</gojibake-glyph-fragment><gojibake-glyph-fragment region="top-right" placement="same-side">右上</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-left" placement="same-side">左下</gojibake-glyph-fragment><gojibake-glyph-fragment region="bottom-right" placement="same-side">右下</gojibake-glyph-fragment>',
+          "基",
         );
 
         glyph.connectedCallback();
 
         expect(readFragments(glyph)).toHaveLength(0);
-        expect(readBase(glyph).classList.contains("base--fallback")).toBe(true);
+        expect(readBase(glyph)).toBeNull();
+        expect(readSlot(glyph)).not.toBeNull();
       });
     });
 
     describe("不正な子要素", () => {
-      it("非対応の子要素が混ざると描画を止める", () => {
-        const glyph = renderGlyphFixture("基", "<span></span>");
+      it("非対応の子要素が混ざると light DOM をそのまま表示する", () => {
+        const glyph = renderGlyphFixture("<span></span>", "基");
         glyph.connectedCallback();
 
         expect(readFragments(glyph)).toHaveLength(0);
-        expect(readBase(glyph).classList.contains("base--fallback")).toBe(true);
+        expect(readBase(glyph)).toBeNull();
+        expect(readSlot(glyph)).not.toBeNull();
       });
     });
   });

--- a/src/glitch/gojibake-glyph-element.ts
+++ b/src/glitch/gojibake-glyph-element.ts
@@ -53,16 +53,10 @@ const SHADOW_CSS = `
   position: relative;
   display: inline-grid;
   place-items: center;
-}
-
-.base {
-  display: block;
-  text-align: center;
-  opacity: 0;
-}
-
-.base--fallback {
-  opacity: 1;
+  inline-size: 1ic;
+  block-size: 1ic;
+  overflow: hidden;
+  vertical-align: text-bottom;
 }
 
 .fragment {
@@ -154,16 +148,16 @@ function isOneOf<T extends string>(value: string, choices: readonly T[]): value 
 /**
  * composite（dual / quad）グリッチ効果を表示するカスタム要素。
  *
- * - `textContent` に元文字を指定する
  * - 各断片は `<gojibake-glyph-fragment>` 子要素の `textContent` で指定する
  * - 子要素数が 2 のとき dual、4 のとき quad とみなす
  *   - dual の場合: 各子要素は本文と `region`, `placement` を持つ
  *   - quad の場合: 各子要素は本文と `region`, `placement` を持つ
+ * - 正常系では 1 文字セル（1ic × 1ic）として断片だけを重ねて描画する
+ * - 構成が不正な場合は合成描画を諦め、light DOM をそのまま表示する
  *
  * @example
  * // dual composite（上下分割）
  * // <gojibake-glyph>
- * //   あ
  * //   <gojibake-glyph-fragment region="top" placement="same-side">い</gojibake-glyph-fragment>
  * //   <gojibake-glyph-fragment region="bottom" placement="opposite-side">う</gojibake-glyph-fragment>
  * // </gojibake-glyph>
@@ -200,18 +194,14 @@ export class GojibakeGlyphElement extends HTMLElement {
   }
 
   private render(): void {
-    const baseChar = this.readBaseChar();
     const fragments = this.readRenderFragments();
 
-    const base = document.createElement("span");
-    base.className = "base";
     if (fragments.length === 0) {
-      base.classList.add("base--fallback");
+      this.renderLightDom();
+      return;
     }
-    base.textContent = baseChar === " " ? "\u00a0" : baseChar;
 
     const df = document.createDocumentFragment();
-    df.appendChild(base);
 
     for (const fragment of fragments) {
       const span = document.createElement("span");
@@ -228,18 +218,13 @@ export class GojibakeGlyphElement extends HTMLElement {
     this.shadow.replaceChildren(df);
   }
 
-  private readBaseChar(): string {
-    return Array.from(this.childNodes)
-      .filter((node): node is Text => node.nodeType === Node.TEXT_NODE)
-      .map((node) => node.data)
-      .join("");
+  private renderLightDom(): void {
+    this.shadow.replaceChildren(document.createElement("slot"));
   }
 
   /**
    * 子要素を読み取り、span 生成に必要な情報へ正規化する。
    * 子要素数が 2 なら dual、4 なら quad として扱う。それ以外は空配列を返す。
-   *
-   * 不正な構成は現段階では描画挙動を変えず、警告だけを出す。
    */
   private readRenderFragments(): RenderFragment[] {
     if (this.layout === "dual") {

--- a/src/glitch/renderer.ts
+++ b/src/glitch/renderer.ts
@@ -25,7 +25,6 @@ export class GlitchRenderer {
    * @example
    * // source = "AB" で A が dual composite、B が通常文字の場合:
    * // <gojibake-glyph>
-   * //   A
    * //   <gojibake-glyph-fragment region="top" placement="same-side">い</gojibake-glyph-fragment>
    * //   <gojibake-glyph-fragment region="bottom" placement="opposite-side">う</gojibake-glyph-fragment>
    * // </gojibake-glyph>
@@ -66,7 +65,7 @@ export class GlitchRenderer {
     }
 
     if (effect?.kind === "composite") {
-      return this.buildCompositeCharElement(sourceChar, effect.composite);
+      return this.buildCompositeCharElement(effect.composite);
     }
 
     // replacement の場合は置換後の文字、それ以外は元の文字を表示する
@@ -85,16 +84,13 @@ export class GlitchRenderer {
   /**
    * composite エフェクトを表す `<gojibake-glyph>` カスタム要素を生成する。
    *
-   * 元文字は `textContent`、各断片は `<gojibake-glyph-fragment>` 子要素として構築する。
-   * clip/place への変換と Shadow DOM 内のレンダリングはカスタム要素側で行う。
+   * 各断片は `<gojibake-glyph-fragment>` 子要素として構築する。
+   * 1 文字セルの寸法決定と clip/place への変換はカスタム要素側で行う。
    *
-   * @param sourceChar 元テキストの1文字
    * @param composite 適用するcompositeエントリ
    */
-  private buildCompositeCharElement(sourceChar: string, composite: CompositeEntry): HTMLElement {
+  private buildCompositeCharElement(composite: CompositeEntry): HTMLElement {
     const el = document.createElement("gojibake-glyph");
-    // 空白文字は見た目上スペースを維持するためにノーブレークスペースに置換する
-    el.textContent = sourceChar === " " ? "\u00a0" : sourceChar;
 
     if (composite.kind === "dual") {
       composite.fragments.forEach((fragment) => {


### PR DESCRIPTION
## 概要
- `gojibake-glyph` の正常系を 1 文字セルとして fragment のみで描画するよう変更
- 不正構成時は独自フォールバックせず light DOM をそのまま表示するよう変更
- renderer とテストを新しい契約に合わせて整理

## 確認
- bun run check
- bun run typecheck
- bun test