### PR TITLE
refactor: prepare elements package for dist builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,21 +5,25 @@
 ## ディレクトリ構成
 
 - `apps/site/` … Bun HTML bundler で配信するデモサイト（`index.html`、`styles.css`、`src/main.ts`）
-- `packages/elements/` … カスタム要素・レンダラー・状態生成（`gojibake-elements`。将来の npm 公開候補）
+- `packages/elements/` … カスタム要素・レンダラー・状態生成（`gojibake-elements`。npm 公開前段のパッケージ）
+- `packages/elements/src/` … パッケージの実装ソース。公開面は `src/index.ts` に集約する
+- `packages/elements/dist/` … `gojibake-elements` の配布前提ビルド成果物。`package.json` の `exports` / `types` はここを指す
 - `apps/site/dist/` … `bun run build` の出力（GitHub Pages などの配信元）
+- `tsconfig.base.json` … 各ワークスペースで共有する TypeScript compilerOptions
 
 ## ビルド・テスト・Lint コマンド
 
 ルートから実行します（ワークスペースまとめてインストール）。
 
 - セットアップ: `mise install` / `bun install`
-- ビルド: `bun run build`
-- 開発確認: `bun run dev`
+- ビルド: `bun run build`（Bun workspace の依存順実行で `packages/elements/dist/` から `apps/site/dist/` を生成する）
+- 開発確認: `bun run dev`（起動前に workspace package のビルドを実行する）
 - Lint, Format: `bun run check:fix`
 - 型チェック: `bun run typecheck`
-- 単体テスト: `bun test`
+- 単体テスト: `bun run test`
+- 総合検証: `bun run check`
 
-単体テストは `packages/elements` 内にあります。変更後は少なくとも `bun run check` を通したうえで、`bun run dev` によるブラウザ確認を行います。
+単体テストは `packages/elements` 内にあります。`bun run check` は lint、ビルド、型チェック、単体テストをまとめて実行します。workspace 横断の実行は Bun の `--filter` を使い、個別 package の `prebuild` には依存先 package のビルドを書かない方針です。変更後は少なくとも `bun run check` を通したうえで、描画に関わる変更では `bun run dev` によるブラウザ確認を行います。
 
 ## 高レベルアーキテクチャ
 
@@ -38,6 +42,13 @@
   - `GlitchRenderer` クラス：`DisplayState` をDOMに反映する
   - `GojibakeGlyphElement` クラス：文字化け演出がある1文字を表す自律カスタム要素
   - `GojibakeGlyphFragmentElement` クラス：`GojibakeGlyphElement` の子要素として文字化け演出の特定の部位を表す
+- `packages/elements/package.json`
+  - `exports` / `types` は `dist` を指す。サイト側も公開パッケージ境界越しに `gojibake-elements` を利用する
+  - 誤公開防止のため、実際に npm 公開するまでは `private: true` を維持する
+- `tsconfig.base.json` と各 `tsconfig.json`
+  - 共通の TypeScript 設定は `tsconfig.base.json` に置く
+  - `packages/elements/tsconfig.json` は `tsc -p .` で `dist` へ配布物を生成できる設定にする
+  - 型チェックでは `tsc --noEmit -p ...` を CLI 側で付ける
 
 ## コードスタイル
 

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "prebuild": "rm -rf dist",
     "build": "bun build ./index.html --outdir ./dist --target browser",
-    "dev": "bun ./index.html"
+    "dev": "bun ./index.html",
+    "typecheck": "tsc --noEmit -p ."
   },
   "dependencies": {
     "gojibake-elements": "workspace:*"

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -1,13 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "lib": ["DOM", "ES2022"],
-    "strict": true,
-    "noEmitOnError": true,
-    "skipLibCheck": true,
-    "noEmit": true
-  },
+  "extends": "../../tsconfig.base.json",
   "include": ["src/**/*.ts"]
 }

--- a/biome.json
+++ b/biome.json
@@ -16,6 +16,7 @@
       "**/packages/**/package.json",
       "**/apps/**/package.json",
       "tsconfig.json",
+      "tsconfig.base.json",
       "**/packages/**/tsconfig.json",
       "**/apps/**/tsconfig.json",
       "biome.json",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,14 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "bun run --cwd apps/site build",
-    "dev": "bun run --cwd apps/site dev",
-    "test": "bun test",
-    "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov",
+    "build": "bun --filter '*' build",
+    "build:packages": "bun --filter './packages/*' build",
+    "dev": "bun run build:packages && bun --filter gojibake-site dev",
+    "test": "bun --filter '*' --if-present test",
+    "test:coverage": "bun --filter '*' --if-present test:coverage",
     "check:fix": "biome check . --write",
-    "check": "biome check . && bun run build",
-    "typecheck": "tsc --noEmit -p packages/elements && tsc --noEmit -p apps/site"
+    "check": "biome check . && bun run build && bun run typecheck && bun run test",
+    "typecheck": "bun run build:packages && bun --filter '*' typecheck"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -3,11 +3,23 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "exports": {
-    ".": "./src/index.ts"
+  "main": "./dist/index.js",
+  "scripts": {
+    "prebuild": "rm -rf dist",
+    "build": "tsc -p .",
+    "typecheck": "tsc --noEmit -p .",
+    "test": "bun test --preload ../../test-setup.ts src",
+    "test:coverage": "bun test --preload ../../test-setup.ts --coverage --coverage-reporter=text --coverage-reporter=lcov src"
   },
-  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "types": "./dist/index.d.ts",
   "files": [
-    "src"
+    "dist"
   ]
 }

--- a/packages/elements/tsconfig.json
+++ b/packages/elements/tsconfig.json
@@ -1,15 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "lib": ["DOM", "ES2022"],
-    "strict": true,
-    "noEmitOnError": true,
     "rootDir": "./src",
     "outDir": "./dist",
-    "skipLibCheck": true,
-    "noEmit": true
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/node_modules/**", "src/**/*.test.ts"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["DOM", "ES2022"],
+    "strict": true,
+    "noEmitOnError": true,
+    "skipLibCheck": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "lib": ["DOM", "ES2022"],
-    "strict": true,
-    "noEmitOnError": true,
-    "skipLibCheck": true,
-    "noEmit": true
-  },
+  "extends": "./tsconfig.base.json",
   "include": ["packages/elements/src/**/*.ts", "apps/site/src/**/*.ts"],
   "exclude": ["**/node_modules/**", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- Point `gojibake-elements` package metadata at generated `dist` output for exports, types, and package files.
- Use Bun workspace filtering for build, typecheck, test, and coverage scripts instead of package-local dependency build chaining.
- Split shared TypeScript compiler options into `tsconfig.base.json` and document the updated monorepo workflow in `AGENTS.md`.

## Test plan
- `bun run check:fix`
- `bun run check`
- `bun run test:coverage`
- `bun pm pack --dry-run` in `packages/elements`


Made with [Cursor](https://cursor.com)