### PR TITLE
test: cover gojibake elements behavior

### DIFF
--- a/packages/elements/src/composite-effect-builder.test.ts
+++ b/packages/elements/src/composite-effect-builder.test.ts
@@ -17,108 +17,234 @@ function mockRandomSequence(values: number[]): void {
 }
 
 describe("buildCompositeEffects", () => {
-  it("candidateIndices が空なら空の map を返す", () => {
-    const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [], {
-      compositeChance: 1,
-      mutateChance: 1,
-      quadChance: 1,
-    });
+  describe("composite 対象の同値クラス", () => {
+    it("候補 index が空なら空の map を返す", () => {
+      const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [], {
+        compositeChance: 1,
+        mutateChance: 1,
+        quadChance: 1,
+      });
 
-    expect(composites.size).toBe(0);
-  });
-
-  it("compositeChance が 0 なら composite を作らない", () => {
-    mockRandomSequence([0]);
-
-    const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
-      compositeChance: 0,
-      mutateChance: 1,
-      quadChance: 1,
-    });
-
-    expect(composites.size).toBe(0);
-  });
-
-  it("dual composite を縦分割で作る", () => {
-    mockRandomSequence([
-      0, // compositeChance
-      0.9, // quadChance: dual
-      0, // vertical
-      0, // first mutate
-      0, // first placement
-      0, // second mutate
-      0.9, // second placement
-    ]);
-
-    const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
-      compositeChance: 1,
-      mutateChance: 1,
-      quadChance: 0,
-    });
-
-    expect(composites.get(0)).toEqual({
-      kind: "dual",
-      fragments: [
-        { char: "A!", position: "top", placement: "same-side" },
-        { char: "A!", position: "bottom", placement: "opposite-side" },
-      ],
+      expect(composites.size).toBe(0);
     });
   });
 
-  it("dual composite を横分割で作る", () => {
-    mockRandomSequence([
-      0, // compositeChance
-      0.9, // quadChance: dual
-      0.9, // horizontal
-      0.9, // first mutate: keep source
-      0, // first placement
-      0.9, // second mutate: keep source
-      0.9, // second placement
-    ]);
+  describe("compositeChance の境界", () => {
+    it("乱数が compositeChance と同じなら composite を作らない", () => {
+      mockRandomSequence([0.5]);
 
-    const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
-      compositeChance: 1,
-      mutateChance: 0,
-      quadChance: 0,
+      const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+        compositeChance: 0.5,
+        mutateChance: 1,
+        quadChance: 1,
+      });
+
+      expect(composites.size).toBe(0);
     });
 
-    expect(composites.get(0)).toEqual({
-      kind: "dual",
-      fragments: [
-        { char: "A", position: "left", placement: "same-side" },
-        { char: "A", position: "right", placement: "opposite-side" },
-      ],
+    it("乱数が compositeChance 未満なら composite を作る", () => {
+      mockRandomSequence([
+        0.49, // compositeChance
+        0.9, // quadChance: dual
+        0, // vertical
+        0.9, // first mutate: keep source
+        0, // first placement
+        0.9, // second mutate: keep source
+        0, // second placement
+      ]);
+
+      const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+        compositeChance: 0.5,
+        mutateChance: 0,
+        quadChance: 0,
+      });
+
+      expect(composites.get(0)?.kind).toBe("dual");
     });
   });
 
-  it("quad composite を 4 象限で作る", () => {
-    mockRandomSequence([
-      0, // compositeChance
-      0, // quadChance
-      0, // top-left mutate
-      0, // top-left placement
-      0, // top-right mutate
-      0.9, // top-right placement
-      0, // bottom-left mutate
-      0, // bottom-left placement
-      0, // bottom-right mutate
-      0.9, // bottom-right placement
-    ]);
+  describe("composite 形状の同値クラス", () => {
+    it("quadChance 境界と同じ乱数なら dual composite を作る", () => {
+      mockRandomSequence([
+        0, // compositeChance
+        0.5, // quadChance: boundary means dual
+        0, // vertical
+        0.9, // first mutate: keep source
+        0, // first placement
+        0.9, // second mutate: keep source
+        0, // second placement
+      ]);
 
-    const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
-      compositeChance: 1,
-      mutateChance: 1,
-      quadChance: 1,
+      const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+        compositeChance: 1,
+        mutateChance: 0,
+        quadChance: 0.5,
+      });
+
+      expect(composites.get(0)?.kind).toBe("dual");
     });
 
-    expect(composites.get(0)).toEqual({
-      kind: "quad",
-      fragments: [
-        { char: "A!", quadrant: "top-left", placement: "same-side" },
-        { char: "A!", quadrant: "top-right", placement: "opposite-side" },
-        { char: "A!", quadrant: "bottom-left", placement: "same-side" },
-        { char: "A!", quadrant: "bottom-right", placement: "opposite-side" },
-      ],
+    it("乱数が quadChance 未満なら quad composite を作る", () => {
+      mockRandomSequence([
+        0, // compositeChance
+        0.49, // quadChance
+        0.9, // top-left mutate: keep source
+        0, // top-left placement
+        0.9, // top-right mutate: keep source
+        0, // top-right placement
+        0.9, // bottom-left mutate: keep source
+        0, // bottom-left placement
+        0.9, // bottom-right mutate: keep source
+        0, // bottom-right placement
+      ]);
+
+      const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+        compositeChance: 1,
+        mutateChance: 0,
+        quadChance: 0.5,
+      });
+
+      expect(composites.get(0)).toEqual({
+        kind: "quad",
+        fragments: [
+          { char: "A", quadrant: "top-left", placement: "same-side" },
+          { char: "A", quadrant: "top-right", placement: "same-side" },
+          { char: "A", quadrant: "bottom-left", placement: "same-side" },
+          { char: "A", quadrant: "bottom-right", placement: "same-side" },
+        ],
+      });
+    });
+
+    it("dual composite は縦分割を作れる", () => {
+      mockRandomSequence([
+        0, // compositeChance
+        0.9, // quadChance: dual
+        0, // vertical
+        0.9, // first mutate: keep source
+        0, // first placement
+        0.9, // second mutate: keep source
+        0, // second placement
+      ]);
+
+      const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+        compositeChance: 1,
+        mutateChance: 0,
+        quadChance: 0,
+      });
+
+      expect(composites.get(0)).toEqual({
+        kind: "dual",
+        fragments: [
+          { char: "A", position: "top", placement: "same-side" },
+          { char: "A", position: "bottom", placement: "same-side" },
+        ],
+      });
+    });
+
+    it("dual composite は横分割を作れる", () => {
+      mockRandomSequence([
+        0, // compositeChance
+        0.9, // quadChance: dual
+        0.9, // horizontal
+        0.9, // first mutate: keep source
+        0, // first placement
+        0.9, // second mutate: keep source
+        0, // second placement
+      ]);
+
+      const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+        compositeChance: 1,
+        mutateChance: 0,
+        quadChance: 0,
+      });
+
+      expect(composites.get(0)).toEqual({
+        kind: "dual",
+        fragments: [
+          { char: "A", position: "left", placement: "same-side" },
+          { char: "A", position: "right", placement: "same-side" },
+        ],
+      });
+    });
+  });
+
+  describe("断片の文字と配置", () => {
+    it("mutateChance 境界と同じ乱数なら元文字を維持する", () => {
+      mockRandomSequence([
+        0, // compositeChance
+        0.9, // quadChance: dual
+        0, // vertical
+        0.5, // first mutate: boundary means keep source
+        0, // first placement
+        0.5, // second mutate: boundary means keep source
+        0, // second placement
+      ]);
+
+      const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+        compositeChance: 1,
+        mutateChance: 0.5,
+        quadChance: 0,
+      });
+
+      expect(composites.get(0)).toEqual({
+        kind: "dual",
+        fragments: [
+          { char: "A", position: "top", placement: "same-side" },
+          { char: "A", position: "bottom", placement: "same-side" },
+        ],
+      });
+    });
+
+    it("mutateChance 未満の乱数なら置換文字を使う", () => {
+      mockRandomSequence([
+        0, // compositeChance
+        0.9, // quadChance: dual
+        0, // vertical
+        0.49, // first mutate
+        0, // first placement
+        0.49, // second mutate
+        0, // second placement
+      ]);
+
+      const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+        compositeChance: 1,
+        mutateChance: 0.5,
+        quadChance: 0,
+      });
+
+      expect(composites.get(0)).toEqual({
+        kind: "dual",
+        fragments: [
+          { char: "A!", position: "top", placement: "same-side" },
+          { char: "A!", position: "bottom", placement: "same-side" },
+        ],
+      });
+    });
+
+    it("placement の乱数が 0.5 未満なら same-side、0.5 以上なら opposite-side にする", () => {
+      mockRandomSequence([
+        0, // compositeChance
+        0.9, // quadChance: dual
+        0, // vertical
+        0.9, // first mutate: keep source
+        0.49, // first placement
+        0.9, // second mutate: keep source
+        0.5, // second placement
+      ]);
+
+      const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+        compositeChance: 1,
+        mutateChance: 0,
+        quadChance: 0,
+      });
+
+      expect(composites.get(0)).toEqual({
+        kind: "dual",
+        fragments: [
+          { char: "A", position: "top", placement: "same-side" },
+          { char: "A", position: "bottom", placement: "opposite-side" },
+        ],
+      });
     });
   });
 });

--- a/packages/elements/src/composite-effect-builder.test.ts
+++ b/packages/elements/src/composite-effect-builder.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+import { buildCompositeEffects } from "./composite-effect-builder.ts";
+
+afterEach(() => {
+  mock.restore();
+});
+
+function mockRandomSequence(values: number[]): void {
+  let index = 0;
+
+  spyOn(Math, "random").mockImplementation(() => {
+    const value = values[index];
+    index += 1;
+    return value ?? 0;
+  });
+}
+
+describe("buildCompositeEffects", () => {
+  it("candidateIndices が空なら空の map を返す", () => {
+    const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [], {
+      compositeChance: 1,
+      mutateChance: 1,
+      quadChance: 1,
+    });
+
+    expect(composites.size).toBe(0);
+  });
+
+  it("compositeChance が 0 なら composite を作らない", () => {
+    mockRandomSequence([0]);
+
+    const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+      compositeChance: 0,
+      mutateChance: 1,
+      quadChance: 1,
+    });
+
+    expect(composites.size).toBe(0);
+  });
+
+  it("dual composite を縦分割で作る", () => {
+    mockRandomSequence([
+      0, // compositeChance
+      0.9, // quadChance: dual
+      0, // vertical
+      0, // first mutate
+      0, // first placement
+      0, // second mutate
+      0.9, // second placement
+    ]);
+
+    const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+      compositeChance: 1,
+      mutateChance: 1,
+      quadChance: 0,
+    });
+
+    expect(composites.get(0)).toEqual({
+      kind: "dual",
+      fragments: [
+        { char: "A!", position: "top", placement: "same-side" },
+        { char: "A!", position: "bottom", placement: "opposite-side" },
+      ],
+    });
+  });
+
+  it("dual composite を横分割で作る", () => {
+    mockRandomSequence([
+      0, // compositeChance
+      0.9, // quadChance: dual
+      0.9, // horizontal
+      0.9, // first mutate: keep source
+      0, // first placement
+      0.9, // second mutate: keep source
+      0.9, // second placement
+    ]);
+
+    const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+      compositeChance: 1,
+      mutateChance: 0,
+      quadChance: 0,
+    });
+
+    expect(composites.get(0)).toEqual({
+      kind: "dual",
+      fragments: [
+        { char: "A", position: "left", placement: "same-side" },
+        { char: "A", position: "right", placement: "opposite-side" },
+      ],
+    });
+  });
+
+  it("quad composite を 4 象限で作る", () => {
+    mockRandomSequence([
+      0, // compositeChance
+      0, // quadChance
+      0, // top-left mutate
+      0, // top-left placement
+      0, // top-right mutate
+      0.9, // top-right placement
+      0, // bottom-left mutate
+      0, // bottom-left placement
+      0, // bottom-right mutate
+      0.9, // bottom-right placement
+    ]);
+
+    const composites = buildCompositeEffects((char) => `${char}!`, ["A"], [0], {
+      compositeChance: 1,
+      mutateChance: 1,
+      quadChance: 1,
+    });
+
+    expect(composites.get(0)).toEqual({
+      kind: "quad",
+      fragments: [
+        { char: "A!", quadrant: "top-left", placement: "same-side" },
+        { char: "A!", quadrant: "top-right", placement: "opposite-side" },
+        { char: "A!", quadrant: "bottom-left", placement: "same-side" },
+        { char: "A!", quadrant: "bottom-right", placement: "opposite-side" },
+      ],
+    });
+  });
+});

--- a/packages/elements/src/index.test.ts
+++ b/packages/elements/src/index.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  GojibakeGlyphElement,
+  GojibakeGlyphFragmentElement,
+  registerGojibakeElements,
+} from "./index.ts";
+
+describe("registerGojibakeElements", () => {
+  it("カスタム要素を登録する", () => {
+    registerGojibakeElements();
+
+    expect(customElements.get("gojibake-glyph-fragment")).toBe(GojibakeGlyphFragmentElement);
+    expect(customElements.get("gojibake-glyph")).toBe(GojibakeGlyphElement);
+  });
+
+  it("既に登録済みなら再定義しない", () => {
+    registerGojibakeElements();
+
+    const originalDefine = customElements.define;
+    const defineCalls: string[] = [];
+
+    customElements.define = ((name, elementConstructor, options) => {
+      defineCalls.push(name);
+      return originalDefine.call(customElements, name, elementConstructor, options);
+    }) as CustomElementRegistry["define"];
+
+    try {
+      registerGojibakeElements();
+    } finally {
+      customElements.define = originalDefine;
+    }
+
+    expect(defineCalls).toEqual([]);
+  });
+});

--- a/packages/elements/src/renderer.test.ts
+++ b/packages/elements/src/renderer.test.ts
@@ -23,6 +23,16 @@ function render(source: string, state: DisplayState): HTMLElement {
 }
 
 describe("GlitchRenderer", () => {
+  it("source が空なら target を空にする", () => {
+    const target = document.createElement("div");
+    target.textContent = "古い内容";
+    const renderer = new GlitchRenderer({ source: "", target });
+
+    renderer.renderDisplayState({ effects: new Map() });
+
+    expect(target.childNodes).toHaveLength(0);
+  });
+
   it("通常文字を .char と .char__base で描画する", () => {
     const target = render("AB", { effects: new Map() });
 
@@ -41,6 +51,14 @@ describe("GlitchRenderer", () => {
     expect(
       Array.from(target.querySelectorAll(".char__base")).map((node) => node.textContent),
     ).toEqual(["A", "Z"]);
+  });
+
+  it("source の範囲外にある effect は描画に影響しない", () => {
+    const target = render("A", {
+      effects: new Map([[1, { kind: "replacement", replacementChar: "Z" }]]),
+    });
+
+    expect(target.textContent).toBe("A");
   });
 
   it("空白を NBSP、改行を br として描画する", () => {

--- a/packages/elements/src/renderer.test.ts
+++ b/packages/elements/src/renderer.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "bun:test";
+
+import { GojibakeGlyphElement } from "./gojibake-glyph-element.ts";
+import { GojibakeGlyphFragmentElement } from "./gojibake-glyph-fragment-element.ts";
+import { GlitchRenderer } from "./renderer.ts";
+import type { DisplayState } from "./state-factory.ts";
+
+if (!customElements.get("gojibake-glyph-fragment")) {
+  customElements.define("gojibake-glyph-fragment", GojibakeGlyphFragmentElement);
+}
+
+if (!customElements.get("gojibake-glyph")) {
+  customElements.define("gojibake-glyph", GojibakeGlyphElement);
+}
+
+function render(source: string, state: DisplayState): HTMLElement {
+  const target = document.createElement("div");
+  const renderer = new GlitchRenderer({ source, target });
+
+  renderer.renderDisplayState(state);
+
+  return target;
+}
+
+describe("GlitchRenderer", () => {
+  it("通常文字を .char と .char__base で描画する", () => {
+    const target = render("AB", { effects: new Map() });
+
+    expect(target.children).toHaveLength(2);
+    expect(target.querySelectorAll(".char")).toHaveLength(2);
+    expect(
+      Array.from(target.querySelectorAll(".char__base")).map((node) => node.textContent),
+    ).toEqual(["A", "B"]);
+  });
+
+  it("replacement effect の文字を描画する", () => {
+    const target = render("AB", {
+      effects: new Map([[1, { kind: "replacement", replacementChar: "Z" }]]),
+    });
+
+    expect(
+      Array.from(target.querySelectorAll(".char__base")).map((node) => node.textContent),
+    ).toEqual(["A", "Z"]);
+  });
+
+  it("空白を NBSP、改行を br として描画する", () => {
+    const target = render("A \nB", { effects: new Map() });
+
+    expect(target.childNodes[1].textContent).toBe("\u00a0");
+    expect(target.childNodes[2]).toBeInstanceOf(HTMLBRElement);
+  });
+
+  it("dual composite effect を gojibake-glyph と fragment 群で描画する", () => {
+    const target = render("A", {
+      effects: new Map([
+        [
+          0,
+          {
+            kind: "composite",
+            composite: {
+              kind: "dual",
+              fragments: [
+                { char: "上", position: "top", placement: "same-side" },
+                { char: "下", position: "bottom", placement: "opposite-side" },
+              ],
+            },
+          },
+        ],
+      ]),
+    });
+
+    const glyph = target.firstElementChild;
+    const fragments = Array.from(glyph?.children ?? []) as GojibakeGlyphFragmentElement[];
+
+    expect(glyph?.tagName).toBe("GOJIBAKE-GLYPH");
+    expect(fragments.map((fragment) => fragment.tagName)).toEqual([
+      "GOJIBAKE-GLYPH-FRAGMENT",
+      "GOJIBAKE-GLYPH-FRAGMENT",
+    ]);
+    expect(fragments.map((fragment) => fragment.textContent)).toEqual(["上", "下"]);
+    expect(fragments.map((fragment) => fragment.region)).toEqual(["top", "bottom"]);
+    expect(fragments.map((fragment) => fragment.placement)).toEqual(["same-side", "opposite-side"]);
+  });
+
+  it("quad composite effect を gojibake-glyph と 4 fragment で描画する", () => {
+    const target = render("A", {
+      effects: new Map([
+        [
+          0,
+          {
+            kind: "composite",
+            composite: {
+              kind: "quad",
+              fragments: [
+                { char: "左上", quadrant: "top-left", placement: "same-side" },
+                { char: "右上", quadrant: "top-right", placement: "opposite-side" },
+                { char: "左下", quadrant: "bottom-left", placement: "same-side" },
+                { char: "右下", quadrant: "bottom-right", placement: "opposite-side" },
+              ],
+            },
+          },
+        ],
+      ]),
+    });
+
+    const fragments = Array.from(
+      target.querySelectorAll("gojibake-glyph-fragment"),
+    ) as GojibakeGlyphFragmentElement[];
+
+    expect(fragments).toHaveLength(4);
+    expect(fragments.map((fragment) => fragment.region)).toEqual([
+      "top-left",
+      "top-right",
+      "bottom-left",
+      "bottom-right",
+    ]);
+    expect(fragments.map((fragment) => fragment.textContent)).toEqual([
+      "左上",
+      "右上",
+      "左下",
+      "右下",
+    ]);
+  });
+
+  it("再描画時に target の既存内容をクリアする", () => {
+    const target = document.createElement("div");
+    target.innerHTML = "<span>古い内容</span>";
+    const renderer = new GlitchRenderer({ source: "A", target });
+
+    renderer.renderDisplayState({ effects: new Map() });
+
+    expect(target.children).toHaveLength(1);
+    expect(target.textContent).toBe("A");
+  });
+});

--- a/packages/elements/src/replacement-effect-builder.test.ts
+++ b/packages/elements/src/replacement-effect-builder.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildReplacementEffects } from "./replacement-effect-builder.ts";
+
+describe("buildReplacementEffects", () => {
+  it("指定された index に replacement effect を作る", () => {
+    const effects = buildReplacementEffects((char) => `${char}!`, ["A", "B", "C"], [0, 2]);
+
+    expect(effects).toEqual(
+      new Map([
+        [0, { kind: "replacement", replacementChar: "A!" }],
+        [2, { kind: "replacement", replacementChar: "C!" }],
+      ]),
+    );
+  });
+
+  it("対象 index が空なら空の map を返す", () => {
+    const effects = buildReplacementEffects((char) => `${char}!`, ["A"], []);
+
+    expect(effects.size).toBe(0);
+  });
+});

--- a/packages/elements/src/state-factory.test.ts
+++ b/packages/elements/src/state-factory.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+import { type Config, GlitchStateFactory } from "./state-factory.ts";
+
+afterEach(() => {
+  mock.restore();
+});
+
+function mockRandomSequence(values: number[]): void {
+  let index = 0;
+
+  spyOn(Math, "random").mockImplementation(() => {
+    const value = values[index];
+    index += 1;
+    return value ?? 0;
+  });
+}
+
+const baseConfig: Config = {
+  mutationRate: 1,
+  compositeProfile: {
+    compositeChance: 0,
+    mutateChance: 1,
+    quadChance: 0,
+  },
+};
+
+describe("GlitchStateFactory", () => {
+  it("composite に選ばれなかった対象へ replacement effect を作る", () => {
+    const factory = new GlitchStateFactory({
+      config: baseConfig,
+      source: "A",
+      pickGlyphForChar: (char) => `${char}!`,
+    });
+    mockRandomSequence([0, 0]);
+
+    const state = factory.createDisplayState();
+
+    expect(state.effects).toEqual(new Map([[0, { kind: "replacement", replacementChar: "A!" }]]));
+  });
+
+  it("composite に選ばれた index は replacement から除外する", () => {
+    const factory = new GlitchStateFactory({
+      config: {
+        ...baseConfig,
+        compositeProfile: {
+          compositeChance: 1,
+          mutateChance: 1,
+          quadChance: 0,
+        },
+      },
+      source: "A",
+      pickGlyphForChar: (char) => `${char}!`,
+    });
+    mockRandomSequence([
+      0, // target selector
+      0, // compositeChance
+      0.9, // quadChance: dual
+      0, // vertical
+      0, // first mutate
+      0, // first placement
+      0, // second mutate
+      0, // second placement
+    ]);
+
+    const state = factory.createDisplayState();
+
+    expect(state.effects.size).toBe(1);
+    expect(state.effects.get(0)?.kind).toBe("composite");
+  });
+});

--- a/packages/elements/src/state-factory.test.ts
+++ b/packages/elements/src/state-factory.test.ts
@@ -26,46 +26,60 @@ const baseConfig: Config = {
 };
 
 describe("GlitchStateFactory", () => {
-  it("composite に選ばれなかった対象へ replacement effect を作る", () => {
-    const factory = new GlitchStateFactory({
-      config: baseConfig,
-      source: "A",
-      pickGlyphForChar: (char) => `${char}!`,
+  describe("target selection と effect 生成の統合", () => {
+    it("対象文字がなければ effect を作らない", () => {
+      const factory = new GlitchStateFactory({
+        config: baseConfig,
+        source: " \n",
+        pickGlyphForChar: (char) => `${char}!`,
+      });
+
+      const state = factory.createDisplayState();
+
+      expect(state.effects.size).toBe(0);
     });
-    mockRandomSequence([0, 0]);
 
-    const state = factory.createDisplayState();
+    it("composite に選ばれなかった対象へ replacement effect を作る", () => {
+      const factory = new GlitchStateFactory({
+        config: baseConfig,
+        source: "A",
+        pickGlyphForChar: (char) => `${char}!`,
+      });
+      mockRandomSequence([0, 0]);
 
-    expect(state.effects).toEqual(new Map([[0, { kind: "replacement", replacementChar: "A!" }]]));
-  });
+      const state = factory.createDisplayState();
 
-  it("composite に選ばれた index は replacement から除外する", () => {
-    const factory = new GlitchStateFactory({
-      config: {
-        ...baseConfig,
-        compositeProfile: {
-          compositeChance: 1,
-          mutateChance: 1,
-          quadChance: 0,
+      expect(state.effects).toEqual(new Map([[0, { kind: "replacement", replacementChar: "A!" }]]));
+    });
+
+    it("composite に選ばれた index は replacement から除外する", () => {
+      const factory = new GlitchStateFactory({
+        config: {
+          ...baseConfig,
+          compositeProfile: {
+            compositeChance: 1,
+            mutateChance: 1,
+            quadChance: 0,
+          },
         },
-      },
-      source: "A",
-      pickGlyphForChar: (char) => `${char}!`,
+        source: "A",
+        pickGlyphForChar: (char) => `${char}!`,
+      });
+      mockRandomSequence([
+        0, // target selector
+        0, // compositeChance
+        0.9, // quadChance: dual
+        0, // vertical
+        0, // first mutate
+        0, // first placement
+        0, // second mutate
+        0, // second placement
+      ]);
+
+      const state = factory.createDisplayState();
+
+      expect(state.effects.size).toBe(1);
+      expect(state.effects.get(0)?.kind).toBe("composite");
     });
-    mockRandomSequence([
-      0, // target selector
-      0, // compositeChance
-      0.9, // quadChance: dual
-      0, // vertical
-      0, // first mutate
-      0, // first placement
-      0, // second mutate
-      0, // second placement
-    ]);
-
-    const state = factory.createDisplayState();
-
-    expect(state.effects.size).toBe(1);
-    expect(state.effects.get(0)?.kind).toBe("composite");
   });
 });

--- a/packages/elements/src/target-selector.test.ts
+++ b/packages/elements/src/target-selector.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+import { pickTargetIndices } from "./target-selector.ts";
+
+afterEach(() => {
+  mock.restore();
+});
+
+function mockRandomSequence(values: number[]): void {
+  let index = 0;
+
+  spyOn(Math, "random").mockImplementation(() => {
+    const value = values[index];
+    index += 1;
+    return value ?? 0;
+  });
+}
+
+describe("pickTargetIndices", () => {
+  it("mutationRate が 0 未満なら対象を選ばない", () => {
+    const picked = pickTargetIndices("ABC", -1);
+
+    expect(picked).toEqual([]);
+  });
+
+  it("mutationRate が 1 を超えたら全候補を対象にする", () => {
+    mockRandomSequence([0, 0, 0]);
+
+    const picked = pickTargetIndices("ABC", 2);
+
+    expect(picked).toEqual([0, 1, 2]);
+  });
+
+  it("空白と改行を候補から除外する", () => {
+    mockRandomSequence([0, 0, 0]);
+
+    const picked = pickTargetIndices("A B\nC", 1);
+
+    expect(picked).toEqual([0, 2, 4]);
+  });
+
+  it("Math.round で対象数を決める", () => {
+    mockRandomSequence([0, 0]);
+
+    const picked = pickTargetIndices("ABCD", 0.38);
+
+    expect(picked).toEqual([0, 1]);
+  });
+
+  it("同じ index を重複して返さない", () => {
+    mockRandomSequence([0.99, 0.99, 0.99]);
+
+    const picked = pickTargetIndices("ABC", 1);
+
+    expect(picked).toEqual([2, 1, 0]);
+  });
+});

--- a/packages/elements/src/target-selector.test.ts
+++ b/packages/elements/src/target-selector.test.ts
@@ -17,41 +17,88 @@ function mockRandomSequence(values: number[]): void {
 }
 
 describe("pickTargetIndices", () => {
-  it("mutationRate が 0 未満なら対象を選ばない", () => {
-    const picked = pickTargetIndices("ABC", -1);
+  describe("mutationRate の同値クラス", () => {
+    it("0 未満なら対象を選ばない", () => {
+      const picked = pickTargetIndices("ABC", -1);
 
-    expect(picked).toEqual([]);
+      expect(picked).toEqual([]);
+    });
+
+    it("0 なら対象を選ばない", () => {
+      const picked = pickTargetIndices("ABC", 0);
+
+      expect(picked).toEqual([]);
+    });
+
+    it("0 より大きく 1 より小さいなら割合に応じて対象を選ぶ", () => {
+      mockRandomSequence([0, 0]);
+
+      const picked = pickTargetIndices("ABCD", 0.5);
+
+      expect(picked).toEqual([0, 1]);
+    });
+
+    it("1 なら全候補を対象にする", () => {
+      mockRandomSequence([0, 0, 0]);
+
+      const picked = pickTargetIndices("ABC", 1);
+
+      expect(picked).toEqual([0, 1, 2]);
+    });
+
+    it("1 を超えたら全候補を対象にする", () => {
+      mockRandomSequence([0, 0, 0]);
+
+      const picked = pickTargetIndices("ABC", 2);
+
+      expect(picked).toEqual([0, 1, 2]);
+    });
   });
 
-  it("mutationRate が 1 を超えたら全候補を対象にする", () => {
-    mockRandomSequence([0, 0, 0]);
+  describe("候補文字の同値クラス", () => {
+    it("空文字なら対象を選ばない", () => {
+      const picked = pickTargetIndices("", 1);
 
-    const picked = pickTargetIndices("ABC", 2);
+      expect(picked).toEqual([]);
+    });
 
-    expect(picked).toEqual([0, 1, 2]);
+    it("空白と改行だけなら対象を選ばない", () => {
+      const picked = pickTargetIndices(" \n ", 1);
+
+      expect(picked).toEqual([]);
+    });
+
+    it("空白と改行を候補から除外する", () => {
+      mockRandomSequence([0, 0, 0]);
+
+      const picked = pickTargetIndices("A B\nC", 1);
+
+      expect(picked).toEqual([0, 2, 4]);
+    });
   });
 
-  it("空白と改行を候補から除外する", () => {
-    mockRandomSequence([0, 0, 0]);
+  describe("対象数の丸め境界", () => {
+    it.each([
+      { mutationRate: 0.124, expected: [] },
+      { mutationRate: 0.125, expected: [0] },
+      { mutationRate: 0.374, expected: [0] },
+      { mutationRate: 0.375, expected: [0, 1] },
+    ])("候補数 * mutationRate を四捨五入する: $mutationRate", ({ mutationRate, expected }) => {
+      mockRandomSequence([0, 0]);
 
-    const picked = pickTargetIndices("A B\nC", 1);
+      const picked = pickTargetIndices("ABCD", mutationRate);
 
-    expect(picked).toEqual([0, 2, 4]);
+      expect(picked).toEqual(expected);
+    });
   });
 
-  it("Math.round で対象数を決める", () => {
-    mockRandomSequence([0, 0]);
+  describe("選択済み候補の扱い", () => {
+    it("同じ index を重複して返さない", () => {
+      mockRandomSequence([0.99, 0.99, 0.99]);
 
-    const picked = pickTargetIndices("ABCD", 0.38);
+      const picked = pickTargetIndices("ABC", 1);
 
-    expect(picked).toEqual([0, 1]);
-  });
-
-  it("同じ index を重複して返さない", () => {
-    mockRandomSequence([0.99, 0.99, 0.99]);
-
-    const picked = pickTargetIndices("ABC", 1);
-
-    expect(picked).toEqual([2, 1, 0]);
+      expect(picked).toEqual([2, 1, 0]);
+    });
   });
 });

--- a/packages/elements/src/utils.test.ts
+++ b/packages/elements/src/utils.test.ts
@@ -2,6 +2,13 @@ import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 
 import { collectNonSpaceIndices, getScriptRanges, pickGlyphForChar } from "./utils.ts";
 
+const JAPANESE_RANGES = [
+  [0x3040, 0x309f],
+  [0x30a0, 0x30ff],
+  [0x4e00, 0x9fff],
+  [0xac00, 0xd7a3],
+];
+
 afterEach(() => {
   mock.restore();
 });
@@ -13,39 +20,48 @@ function mockRandom(value: number): void {
 describe("utils", () => {
   describe("getScriptRanges", () => {
     it.each([
-      {
-        char: "あ",
-        expected: [
-          [0x3040, 0x309f],
-          [0x30a0, 0x30ff],
-          [0x4e00, 0x9fff],
-          [0xac00, 0xd7a3],
-        ],
-      },
-      {
-        char: "漢",
-        expected: [
-          [0x3040, 0x309f],
-          [0x30a0, 0x30ff],
-          [0x4e00, 0x9fff],
-          [0xac00, 0xd7a3],
-        ],
-      },
-      { char: "한", expected: [[0xac00, 0xd7a3]] },
-      { char: "A", expected: [[0x0041, 0x005a]] },
-      { char: "a", expected: [[0x0061, 0x007a]] },
-      { char: "1", expected: [[0x0030, 0x0039]] },
-    ])("$char のスクリプト範囲を返す", ({ char, expected }) => {
+      { codePoint: 0x3040, expected: JAPANESE_RANGES, title: "ひらがな範囲の開始" },
+      { codePoint: 0x309f, expected: JAPANESE_RANGES, title: "ひらがな範囲の終了" },
+      { codePoint: 0x30a0, expected: JAPANESE_RANGES, title: "カタカナ範囲の開始" },
+      { codePoint: 0x30ff, expected: JAPANESE_RANGES, title: "カタカナ範囲の終了" },
+      { codePoint: 0x4e00, expected: JAPANESE_RANGES, title: "CJK 統合漢字範囲の開始" },
+      { codePoint: 0x9fff, expected: JAPANESE_RANGES, title: "CJK 統合漢字範囲の終了" },
+      { codePoint: 0xac00, expected: [[0xac00, 0xd7a3]], title: "ハングル音節範囲の開始" },
+      { codePoint: 0xd7a3, expected: [[0xac00, 0xd7a3]], title: "ハングル音節範囲の終了" },
+      { codePoint: 0x0041, expected: [[0x0041, 0x005a]], title: "ASCII 大文字範囲の開始" },
+      { codePoint: 0x005a, expected: [[0x0041, 0x005a]], title: "ASCII 大文字範囲の終了" },
+      { codePoint: 0x0061, expected: [[0x0061, 0x007a]], title: "ASCII 小文字範囲の開始" },
+      { codePoint: 0x007a, expected: [[0x0061, 0x007a]], title: "ASCII 小文字範囲の終了" },
+      { codePoint: 0x0030, expected: [[0x0030, 0x0039]], title: "ASCII 数字範囲の開始" },
+      { codePoint: 0x0039, expected: [[0x0030, 0x0039]], title: "ASCII 数字範囲の終了" },
+    ])("$title なら対応する範囲を返す", ({ codePoint, expected }) => {
+      const char = String.fromCodePoint(codePoint);
+
       expect(getScriptRanges(char)).toEqual(expected);
     });
 
-    it("非対応文字なら null を返す", () => {
-      expect(getScriptRanges("。")).toBeNull();
+    it.each([
+      { codePoint: 0x303f, title: "ひらがな範囲の直前" },
+      { codePoint: 0x3100, title: "カタカナ範囲の直後" },
+      { codePoint: 0x4dff, title: "CJK 統合漢字範囲の直前" },
+      { codePoint: 0xa000, title: "CJK 統合漢字範囲の直後" },
+      { codePoint: 0xabff, title: "ハングル音節範囲の直前" },
+      { codePoint: 0xd7a4, title: "ハングル音節範囲の直後" },
+      { codePoint: 0x0040, title: "ASCII 大文字範囲の直前" },
+      { codePoint: 0x005b, title: "ASCII 大文字範囲の直後" },
+      { codePoint: 0x0060, title: "ASCII 小文字範囲の直前" },
+      { codePoint: 0x007b, title: "ASCII 小文字範囲の直後" },
+      { codePoint: 0x002f, title: "ASCII 数字範囲の直前" },
+      { codePoint: 0x003a, title: "ASCII 数字範囲の直後" },
+    ])("$title なら null を返す", ({ codePoint }) => {
+      const char = String.fromCodePoint(codePoint);
+
+      expect(getScriptRanges(char)).toBeNull();
     });
   });
 
   describe("pickGlyphForChar", () => {
-    it("対応範囲からランダムに文字を選ぶ", () => {
+    it("対応範囲の候補から文字を選ぶ", () => {
       mockRandom(0);
 
       const glyph = pickGlyphForChar("A");

--- a/packages/elements/src/utils.test.ts
+++ b/packages/elements/src/utils.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+import { collectNonSpaceIndices, getScriptRanges, pickGlyphForChar } from "./utils.ts";
+
+afterEach(() => {
+  mock.restore();
+});
+
+function mockRandom(value: number): void {
+  spyOn(Math, "random").mockImplementation(() => value);
+}
+
+describe("utils", () => {
+  describe("getScriptRanges", () => {
+    it.each([
+      {
+        char: "あ",
+        expected: [
+          [0x3040, 0x309f],
+          [0x30a0, 0x30ff],
+          [0x4e00, 0x9fff],
+          [0xac00, 0xd7a3],
+        ],
+      },
+      {
+        char: "漢",
+        expected: [
+          [0x3040, 0x309f],
+          [0x30a0, 0x30ff],
+          [0x4e00, 0x9fff],
+          [0xac00, 0xd7a3],
+        ],
+      },
+      { char: "한", expected: [[0xac00, 0xd7a3]] },
+      { char: "A", expected: [[0x0041, 0x005a]] },
+      { char: "a", expected: [[0x0061, 0x007a]] },
+      { char: "1", expected: [[0x0030, 0x0039]] },
+    ])("$char のスクリプト範囲を返す", ({ char, expected }) => {
+      expect(getScriptRanges(char)).toEqual(expected);
+    });
+
+    it("非対応文字なら null を返す", () => {
+      expect(getScriptRanges("。")).toBeNull();
+    });
+  });
+
+  describe("pickGlyphForChar", () => {
+    it("対応範囲からランダムに文字を選ぶ", () => {
+      mockRandom(0);
+
+      const glyph = pickGlyphForChar("A");
+
+      expect(glyph).toBe("A");
+    });
+
+    it("非対応文字はそのまま返す", () => {
+      expect(pickGlyphForChar("。")).toBe("。");
+    });
+  });
+
+  describe("collectNonSpaceIndices", () => {
+    it("半角空白と改行を除いた index を返す", () => {
+      expect(collectNonSpaceIndices(["A", " ", "B", "\n", "C"])).toEqual([0, 2, 4]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused tests for `GlitchRenderer` DOM output, including replacement, composite glyphs, whitespace, newlines, and rerender clearing.
- Cover state and effect generation logic with deterministic `bun:test` spies for random branches.
- Add tests for target selection, replacement effects, utility glyph selection, and custom element registration.

## Test plan
- [x] `bun run check`


Made with [Cursor](https://cursor.com)