### PR TITLE
ci: npm publish with Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,55 @@
+name: Publish npm packages
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish-gojibake-element
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: publish
+      url: https://www.npmjs.com/package/gojibake-element
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run check
+
+      - name: Verify package version matches release tag
+        if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(node -p "require('./packages/element/package.json').version")"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Tag version v${tag} does not match packages/element/package.json version ${pkg}"
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@^11.5.1
+
+      - name: Publish to npm
+        working-directory: packages/element
+        run: npm publish


### PR DESCRIPTION
## Summary

- Add `.github/workflows/publish-npm.yml` to publish `gojibake-element` from `packages/element` using npm **Trusted Publishing** (OIDC). No `NODE_AUTH_TOKEN` / long-lived publish token in GitHub secrets.
- Triggers: `v*` tag push and `workflow_dispatch`.
- Runs `bun run check` before publish; on tag pushes, verifies the tag matches `packages/element/package.json` `version`.
- Uses GitHub **Environment** `publish` (optional protection rules / reviewers in repo Settings).

## Setup checklist (after merge)

1. **npmjs.com** → package → **Trusted publishing**: GitHub Actions, repository `otariidae/gojibake`, workflow filename **`publish-npm.yml`** (must match exactly).
2. **GitHub** → Settings → **Environments**: create environment **`publish`** if it does not exist; add reviewers / branch rules as desired.

## Note

`.github/hooks/notify.json` was left untracked (local Cursor hook experiment).


Made with [Cursor](https://cursor.com)